### PR TITLE
Brands/yokohama

### DIFF
--- a/.github/workflows/yokohoma.yml
+++ b/.github/workflows/yokohoma.yml
@@ -1,0 +1,25 @@
+name: "yokohoma"
+
+env:
+  brand: "yokohoma"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  main:
+    name: main
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+
+    steps:
+    - name: Check out the repository to the runner
+      uses: actions/checkout@v4
+
+    - name: "Retrieve & upload data"
+      uses: ./.github/workflows/retrieve-upload
+      with:
+        script-name: ${{ env.brand }}

--- a/scripts/dunlop.py
+++ b/scripts/dunlop.py
@@ -5,8 +5,8 @@ import re
 import requests
 from bs4 import BeautifulSoup
 
-from scripts.util.bs_sleep import sleep_with_random
-from scripts.util.location_translator import get_en_province, get_en_city
+from util.bs_sleep import sleep_with_random
+from util.location_translator import get_en_province, get_en_city
 
 RESULT_FIELDS = ["省", "Province", "市", "City", "区", "店名", "类型", "地址", "电话", "备注"]
 DEFAULT_HEADERS = {

--- a/scripts/po/po.py
+++ b/scripts/po/po.py
@@ -1,0 +1,147 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.remote.webelement import WebElement # 方便类型注解
+from selenium.common.exceptions import TimeoutException, StaleElementReferenceException # 异常识别
+
+import logging
+
+
+class BasePage:
+    """Page Object 模型的基类，封装了常见的方法"""
+
+    def __init__(self, driver, base_url: str, timeout: int) -> None:
+        self.driver = driver
+        self.base_url: str = base_url
+        self.timeout: int = timeout
+        self.logger = logging.getLogger(__name__)
+        
+        if base_url:
+            self.driver.get(base_url)
+
+
+    def find_element(self, locator, timeout=None):
+        """查找单个元素（带显式等待）"""
+        timeout = timeout or self.timeout
+        try:
+            return WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_element_located(locator)
+            )
+        except TimeoutException:
+            self.logger.error(f"查找元素超时: {locator}")
+            raise
+
+
+    def find_elements(self, locator, timeout=None):
+        """查找所有元素构成的列表"""
+        timeout = timeout or self.timeout
+        try:
+            return WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_all_elements_located(locator)
+            )
+        except TimeoutException:
+            self.logger.warning(f"查找元素集合超时: {locator}")
+            return []  # 返回空列表而非抛出异常
+    
+
+    def click(self, locator, timeout=None):
+        """点击元素（带等待元素可点击）"""
+        timeout = timeout or self.timeout
+        try:
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.element_to_be_clickable(locator)
+            )
+            element.click()
+        except StaleElementReferenceException:
+            # 元素可能已过时，尝试重新查找
+            self.logger.warning("元素已过时，重新尝试点击")
+            return self.click(locator, timeout)  # 递归重试
+        except TimeoutException:
+            self.logger.error(f"点击元素失败（不可点击或不存在）: {locator}")
+            raise
+
+
+    def get_text(self, locator, timeout=None):
+        """获取元素文本内容"""
+        element = self.find_element(locator, timeout)
+        return element.text.strip()
+    
+    
+    def get_value(self, locator, timeout=None):
+        """获取元素的value值"""
+        element = self.find_element(locator, timeout)
+        return element.value_of_css_property('value').strip()
+    
+
+    def is_visible(self, locator, timeout=None):
+        """检查元素是否可见"""
+        timeout = timeout or self.timeout
+        try:
+            WebDriverWait(self.driver, timeout).until(
+                EC.visibility_of_element_located(locator)
+            )
+            return True
+        except TimeoutException:
+            return False
+        
+
+    def is_clickable(self, locator, timeout=None):
+        """检查元素是否可以点击"""
+        timeout = timeout or self.timeout
+        try:
+            WebDriverWait(self.driver, timeout).until(
+                EC.element_to_be_clickable(locator)
+            )
+            return True
+        except TimeoutException:
+            return False
+        
+
+    # ####################
+    # JavaScript相关方法
+    # ####################
+    
+    def execute_script(self, script, *args):
+        """执行JavaScript脚本"""
+        return self.driver.execute_script(script, *args)
+    
+
+    def scroll_to_element(self, locator: tuple[str, str] | WebElement):
+        """滚动到指定元素位置"""
+        if isinstance(locator, tuple):
+            element = self.find_element(locator)
+        elif isinstance(locator, WebElement):
+            element = locator
+        
+        self.execute_script("arguments[0].scrollIntoView();", element)
+
+
+    # ####################
+    # 等待相关方法
+    # ####################
+    
+    def wait_for_ajax_complete(self, timeout=30):
+        """等待所有AJAX请求完成"""
+        script = "return jQuery.active === 0"  # 仅适用于使用jQuery的网站
+        try:
+            WebDriverWait(self.driver, timeout).until(
+                lambda d: d.execute_script(script) is True
+            )
+        except TimeoutException:
+            self.logger.warning("AJAX请求超时，可能仍有请求未完成")
+    
+    
+    # ####################
+    # Cookies处理
+    # ####################
+    
+    def get_cookies(self):
+        """获取所有Cookies"""
+        return self.driver.get_cookies()
+    
+    
+    def add_cookie(self, cookie_dict):
+        """添加Cookie"""
+        self.driver.add_cookie(cookie_dict)

--- a/scripts/yokohoma.py
+++ b/scripts/yokohoma.py
@@ -1,0 +1,59 @@
+import os
+from bs4 import BeautifulSoup
+
+import requests
+
+RESULT_FIELDS = ["省", "Province", "市", "City", "区", "店名", "类型", "地址", "电话", "备注"]
+DEFAULT_HEADERS = {
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+}
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)  # 进入子目录
+OUTPUT_PATH = os.path.join(PROJECT_ROOT, "output/yokohoma.csv")
+
+
+def main():
+    api = 'https://www.yokohama.com.cn/api/get_comp'
+
+    # 构造请求头和请求体
+
+    payload = ("{\r\n    \"view\": \"Check\",\r\n    \"compId\": \"c_outlets_list_003-1693299992595\","
+               "\r\n    \"params\": \"{\\\"size\\\":2000,\\\"query\\\":[{\\\"valueName\\\":\\\"\\\","
+               "\\\"dataType\\\":\\\"number\\\",\\\"operator\\\":\\\"eq\\\","
+               "\\\"filter\\\":\\\"ignore-empty-check\\\",\\\"esField\\\":\\\"CID\\\",\\\"groupName\\\":\\\"数据展示条件,"
+               "默认条件组\\\",\\\"groupEnd\\\":\\\"2,1\\\",\\\"field\\\":\\\"CID\\\",\\\"sourceType\\\":\\\"page\\\","
+               "\\\"logic\\\":\\\"and\\\",\\\"groupBegin\\\":\\\"1,2\\\",\\\"fieldType\\\":\\\"number\\\"}],"
+               "\\\"header\\\":{\\\"Data-Query-Es-Field\\\":\\\"DETAIL_ES.es_symbol_text_l4B1um48,"
+               "DETAIL_ES.es_symbol_address_420l30H3allAddress,DETAIL_ES.es_symbol_text_7eE767rS,"
+               "DETAIL_ES.es_multi_address_420l30H3tencentMap,DETAIL_ES.es_multi_image_T328TCK7,"
+               "DETAIL_ES.es_float_zdlcm\\\",\\\"Data-Query-Random\\\":0,\\\"Data-Query-Field\\\":\\\"text_l4B1um48,"
+               "address_420l30H3allAddress,text_7eE767rS,address_420l30H3tencentMap,image_T328TCK7,zdlcm\\\"},"
+               "\\\"from\\\":0,\\\"sort\\\":[]}\"\r\n}")
+    headers = {
+        'sec-ch-ua-platform': '"Windows"',
+        'sec-ch-ua': '"Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"',
+        'sec-ch-ua-mobile': '?0',
+        'instance': 'NGC202308040001',
+        'X-Requested-With': 'XMLHttpRequest',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36',
+        'Accept': 'text/html, */*; q=0.01',
+        'DNT': '1',
+        'Content-Type': 'application/json;charset=UTF-8',
+        'Sec-Fetch-Site': 'same-origin',
+        'Sec-Fetch-Mode': 'cors',
+        'Sec-Fetch-Dest': 'empty',
+        'host': 'www.yokohama.com.cn'
+    }
+
+    try:
+        response = requests.post(api, headers=headers, data=payload)
+        response.raise_for_status()
+        soup_response = BeautifulSoup(response.text, 'html.parser')
+        soup_dealers = soup_response.select('div.e_container-32.s_layout > div')
+        print(1)
+    except requests.exceptions.RequestException as e:
+        print(e)
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/yokohoma.py
+++ b/scripts/yokohoma.py
@@ -1,112 +1,175 @@
 import logging
+import csv
 import os
-from os import write
+from time import time
 
 from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.chrome.options import Options
-
-from scripts.util.bs_sleep import sleep_with_random
-from util.location_translator import get_en_city
+from selenium.webdriver.remote.webelement import WebElement # 方便类型注解
+from selenium.common.exceptions import TimeoutException, StaleElementReferenceException # 异常识别
+from util.bs_sleep import sleep_with_random
+from util.location_translator import get_en_city, get_en_province
 import requests
+from urllib.parse import unquote
 
-RESULT_FIELDS = ["省", "Province", "市", "City", "区", "店名", "类型", "地址", "电话", "备注"]
+from po.po import BasePage
+
+RESULT_FIELDS = ["省", "Province", "市区辅助", "City/Area", "区", "店名", "类型", "地址", "电话", "备注"]
 DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)  # 进入子目录
-OUTPUT_PATH = os.path.join(PROJECT_ROOT, "output/yokohoma.csv")
+OUTPUT_DIR = os.path.join(PROJECT_ROOT, "output")
+OUTPUT_PATH = os.path.join(OUTPUT_DIR, 'yokohoma.csv')
 
 
-class Browser:
-    def __init__(self, home_page: str, user_agent: str):
-        self.home_page: str = home_page
+class CheckPage(BasePage):
+    """Check.html页面的类"""
 
-        # logger = logging.getLogger('selenium')
-        #
-        # log_path = 'bridge_log.log'
-        # handler = logging.FileHandler(log_path)
-        # logger.addHandler(handler)
-        # logger.setLevel(logging.DEBUG)
-        # logging.basicConfig(encoding='utf-8')
-
-        chrome_options = Options()
-        # 禁用地理位置权限
-        chrome_options.add_argument("--disable-geolocation")
-        chrome_options.add_argument("--disable-infobars")  # 可选：禁用信息栏提示
-        chrome_options.add_argument("--no-sandbox")  # 禁用沙盒（Linux必加）
-        chrome_options.add_argument("--disable-dev-shm-usage")  # 避免内存不足
-        chrome_options.add_argument("--window-size=1920,1080")  # 设置窗口大小（避免响应式布局问题）
-        # chrome_options.add_argument("--headless=new")  # 启用新版无头模式
-        chrome_options.add_argument("--disable-gpu")  # 可选：禁用GPU加速（旧版需启用）
-        chrome_options.add_argument(f"user-agent={user_agent}")
-
-        # 设置默认拒绝所有网站的定位请求
-        chrome_options.add_experimental_option("prefs", {
-            "profile.default_content_setting_values.geolocation": 2,  # 2=拒绝, 1=允许, 0=询问
-            "profile.default_content_setting_values.notifications": 2,  # 可选：禁用通知
-        })
-
-        self.driver = webdriver.Chrome(options=chrome_options)
-        self.wait = WebDriverWait(self.driver, timeout=3)
-
-        self.province = None
-        self.city = None
-
-        self.btn_province = None
-        self.btn_city = None
-
-        self.btn_city_list: list = list()
-        self.btn_provinces_list: list = list()
+    # Locators
+    MANAGE_COOKIES_BUTTON = (By.CSS_SELECTOR, 'button.btn.btn-outline-primary.p_btSet')
+    REFUSE_COOKIES_BUTTON = (By.CSS_SELECTOR, 'button.btn.btn-outline-primary.p_btRefuse')
+    SELECT_PROVINCE_BUTTON = (By.CSS_SELECTOR, 'div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 省 -"]')
+    SELECT_CITY_BUTTON = (By.CSS_SELECTOR, 'div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 市 -"]')
+    NEXT_PAGE_BUTTON = (By.CSS_SELECTOR, 'div.e_loop-2.s_list.response-transition > div > div.p_page > div > a.page_a.page_next')
 
 
-    def run(self):
-        driver = self.driver
-        home_page = self.home_page
-        wait = self.wait
+    PROVINCE_LIST = (By.CSS_SELECTOR, 'div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 省 -"] > div.select-picker-options-wrp.p_select_options > div.select-picker-options-list.p_o_list > div.select-picker-options-list-item.p_o_item > span')
+    CITY_LIST = (By.CSS_SELECTOR, 'div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 市 -"] > div.select-picker-options-wrp.p_select_options > div.select-picker-options-list.p_o_list > div.select-picker-options-list-item.p_o_item[data-selected="true"] > span')
+    DEALER_LIST = (By.CSS_SELECTOR, 'div.e_loop-2.s_list.response-transition > div > div.p_list > div > div.e_container-8.s_layout > div > div.e_container-32.s_layout > div')
 
-        try:
-            driver.get(home_page)
-            '''拒绝所有Cookie'''
-            btn_manage_cookies = driver.find_element(By.CSS_SELECTOR, value='button.btn.btn-outline-primary.p_btSet')
-            wait.until(lambda _: btn_manage_cookies.is_displayed())
-            btn_manage_cookies.click()
-            sleep_with_random(1, 1)
-            btn_refuse_cookies = driver.find_element(By.CSS_SELECTOR, value='button.btn.btn-outline-primary.p_btRefuse')
-            wait.until(lambda _: btn_refuse_cookies.is_displayed())
-            btn_refuse_cookies.click()
 
-            '''选择省份'''
-            self.btn_province = driver.find_element(By.CSS_SELECTOR, value='div.js-filter-select.p_filter_select.selectPickerWrapper')
-            driver.execute_script("arguments[0].scrollIntoView();", self.btn_province)
 
-            if self.btn_province is None:
-                exit(1)
+    def __init__(self, driver, base_url: str, timeout: int) -> None:
+        super().__init__(driver, base_url, timeout)
+        self.province_str: str = str()
+        self.city_str: str = str()
 
-            wait.until(lambda _: self.btn_province.is_displayed())
-            self.btn_province.click()
 
-            '''获取省份列表'''
-            self.btn_provinces_list = driver.find_elements(By.CSS_SELECTOR, value='div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 省 -"] > div.select-picker-options-wrp.p_select_options > div.select-picker-options-list.p_o_list > div.select-picker-options-list-item.p_o_item > span')
-            wait.until(lambda _:self.btn_provinces_list[0].is_displayed())
-        except TypeError as e:
-            print(e)
-            exit(1)
+    def refuse_all_cookies(self):
+        self.click(self.MANAGE_COOKIES_BUTTON)
+        sleep_with_random(1, 1)
+        self.click(self.REFUSE_COOKIES_BUTTON)
+        sleep_with_random(1, 1)
         
-
-
-        print(1)
-
-
+        
+    def get_province_list(self) -> list[WebElement]:
+        self.scroll_to_element(self.SELECT_PROVINCE_BUTTON)
+        self.click(self.SELECT_PROVINCE_BUTTON)
+        return self.find_elements(self.PROVINCE_LIST)
+    
+    
+    def get_city_list(self) -> list[WebElement]:
+        self.scroll_to_element(self.SELECT_CITY_BUTTON)
+        self.click(self.SELECT_CITY_BUTTON)
+        return self.find_elements(self.CITY_LIST)
+    
+    
+    def get_dealer_list(self) -> list[WebElement]:
+        return self.find_elements(self.DEALER_LIST)
+        
+        
+    def dealer_to_dict(self, dealer: WebElement) -> dict:
+        return {
+            "省": self.province_str,
+            "Province": get_en_province(self.province_str),
+            "市区辅助": self.city_str,
+            "City/Area": get_en_city(self.city_str),
+            "区": str(),
+            "店名": dealer.find_element(By.CSS_SELECTOR, 'p.e_text-4').text.strip(),
+            "类型": str(),
+            "地址": dealer.find_element(By.CSS_SELECTOR, 'p.e_text-6').text.strip(),
+            "电话": dealer.find_element(By.CSS_SELECTOR, 'p.e_text-31').text.strip(),
+            "备注": str()
+        }
+    
+    
+def save_dict_to_csv(path: str, src: dict) -> None:
+    with open(file=path, mode='a', encoding='utf-8', newline='') as fp:
+        writer = csv.DictWriter(f=fp, fieldnames=RESULT_FIELDS, quoting=csv.QUOTE_ALL)
+        writer.writerow(src)
+    
+    
+def init_driver():
+    DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+    chrome_options = Options()
+    # 禁用地理位置权限
+    chrome_options.add_argument("--disable-geolocation")
+    chrome_options.add_argument("--disable-infobars")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--window-size=1920,1080")
+    # chrome_options.add_argument("--headless=new")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument(f"user-agent={DEFAULT_UA}")
+    # 设置默认拒绝所有网站的定位请求
+    chrome_options.add_experimental_option("prefs", {
+        "profile.default_content_setting_values.geolocation": 2,  # 2=拒绝, 1=允许, 0=询问
+        "profile.default_content_setting_values.notifications": 2,  # 可选：禁用通知
+    })
+    return webdriver.Chrome(options=chrome_options)
 
 
 def main():
-    home_page = 'https://www.yokohama.com.cn/Check.html'
+    total_dealers: int = 0
+    
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(file=OUTPUT_PATH, mode='w', encoding='utf-8', newline='') as fp:
+        writer = csv.DictWriter(f=fp, fieldnames=RESULT_FIELDS, quoting=csv.QUOTE_ALL)
+        writer.writeheader()
+    
+    driver = init_driver()
+    
+    check_page = CheckPage(driver, base_url='https://www.yokohama.com.cn/Check.html', timeout=5)
+    
+    check_page.refuse_all_cookies()
+    provinces: list[WebElement] = check_page.get_province_list()
+    sleep_with_random(1, 1)
+    
+    for p in provinces:
+        check_page.province_str = unquote(p.get_attribute('value') or str())
+        check_page.scroll_to_element(p)
+        check_page.click(p, 5)
+        sleep_with_random(1, 1)
+        cities: list[WebElement] = check_page.get_city_list()
+        for c in cities:
+            check_page.city_str = unquote(c.get_attribute('value') or str())
+            check_page.scroll_to_element(c)
+            check_page.click(c, 5)
+            sleep_with_random(1, 1)
+            
+            no_more_pages: bool = False
+            while not no_more_pages:
+                next_button_class: str = check_page.find_element(check_page.NEXT_PAGE_BUTTON).get_attribute('class') or str()
+                next_button_class_list: list[str] = next_button_class.split()
+                if 'disabled' in next_button_class_list:
+                    no_more_pages = True
+                
+                dealers: list[WebElement] = check_page.get_dealer_list()
+                for d in dealers:
+                    dealer_dict: dict = check_page.dealer_to_dict(d)
+                    print(dealer_dict)
+                    save_dict_to_csv(OUTPUT_PATH, dealer_dict)
+                    total_dealers += 1
+                    
+                if not no_more_pages:
+                    # 翻页
+                    check_page.scroll_to_element(check_page.NEXT_PAGE_BUTTON)
+                    check_page.click(check_page.NEXT_PAGE_BUTTON)
+                    sleep_with_random(1, 1)
+            
+            if c != cities[len(cities) - 1]:
+                check_page.click(check_page.SELECT_CITY_BUTTON, 5)
+                sleep_with_random(1, 1)
+        
+        if p != provinces[len(provinces) - 1]:
+            check_page.click(check_page.SELECT_PROVINCE_BUTTON, 5)
+            sleep_with_random(1, 1)
 
-    browser = Browser(home_page, DEFAULT_UA)
-    browser.run()
-
+    print(f'共获取到{total_dealers}家门店')
 
 if __name__ == "__main__":
     main()

--- a/scripts/yokohoma.py
+++ b/scripts/yokohoma.py
@@ -1,19 +1,112 @@
+import logging
 import os
-from bs4 import BeautifulSoup
+from os import write
 
+from bs4 import BeautifulSoup
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.chrome.options import Options
+
+from scripts.util.bs_sleep import sleep_with_random
+from util.location_translator import get_en_city
 import requests
 
 RESULT_FIELDS = ["省", "Province", "市", "City", "区", "店名", "类型", "地址", "电话", "备注"]
-DEFAULT_HEADERS = {
-    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
-}
+DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)  # 进入子目录
 OUTPUT_PATH = os.path.join(PROJECT_ROOT, "output/yokohoma.csv")
 
 
+class Browser:
+    def __init__(self, home_page: str, user_agent: str):
+        self.home_page: str = home_page
+
+        # logger = logging.getLogger('selenium')
+        #
+        # log_path = 'bridge_log.log'
+        # handler = logging.FileHandler(log_path)
+        # logger.addHandler(handler)
+        # logger.setLevel(logging.DEBUG)
+        # logging.basicConfig(encoding='utf-8')
+
+        chrome_options = Options()
+        # 禁用地理位置权限
+        chrome_options.add_argument("--disable-geolocation")
+        chrome_options.add_argument("--disable-infobars")  # 可选：禁用信息栏提示
+        chrome_options.add_argument("--no-sandbox")  # 禁用沙盒（Linux必加）
+        chrome_options.add_argument("--disable-dev-shm-usage")  # 避免内存不足
+        chrome_options.add_argument("--window-size=1920,1080")  # 设置窗口大小（避免响应式布局问题）
+        # chrome_options.add_argument("--headless=new")  # 启用新版无头模式
+        chrome_options.add_argument("--disable-gpu")  # 可选：禁用GPU加速（旧版需启用）
+        chrome_options.add_argument(f"user-agent={user_agent}")
+
+        # 设置默认拒绝所有网站的定位请求
+        chrome_options.add_experimental_option("prefs", {
+            "profile.default_content_setting_values.geolocation": 2,  # 2=拒绝, 1=允许, 0=询问
+            "profile.default_content_setting_values.notifications": 2,  # 可选：禁用通知
+        })
+
+        self.driver = webdriver.Chrome(options=chrome_options)
+        self.wait = WebDriverWait(self.driver, timeout=3)
+
+        self.province = None
+        self.city = None
+
+        self.btn_province = None
+        self.btn_city = None
+
+        self.btn_city_list: list = list()
+        self.btn_provinces_list: list = list()
+
+
+    def run(self):
+        driver = self.driver
+        home_page = self.home_page
+        wait = self.wait
+
+        try:
+            driver.get(home_page)
+            '''拒绝所有Cookie'''
+            btn_manage_cookies = driver.find_element(By.CSS_SELECTOR, value='button.btn.btn-outline-primary.p_btSet')
+            wait.until(lambda _: btn_manage_cookies.is_displayed())
+            btn_manage_cookies.click()
+            sleep_with_random(1, 1)
+            btn_refuse_cookies = driver.find_element(By.CSS_SELECTOR, value='button.btn.btn-outline-primary.p_btRefuse')
+            wait.until(lambda _: btn_refuse_cookies.is_displayed())
+            btn_refuse_cookies.click()
+
+            '''选择省份'''
+            self.btn_province = driver.find_element(By.CSS_SELECTOR, value='div.js-filter-select.p_filter_select.selectPickerWrapper')
+            driver.execute_script("arguments[0].scrollIntoView();", self.btn_province)
+
+            if self.btn_province is None:
+                exit(1)
+
+            wait.until(lambda _: self.btn_province.is_displayed())
+            self.btn_province.click()
+
+            '''获取省份列表'''
+            self.btn_provinces_list = driver.find_elements(By.CSS_SELECTOR, value='div.js-filter-select.p_filter_select.selectPickerWrapper[placeholder="- 省 -"] > div.select-picker-options-wrp.p_select_options > div.select-picker-options-list.p_o_list > div.select-picker-options-list-item.p_o_item > span')
+            wait.until(lambda _:self.btn_provinces_list[0].is_displayed())
+        except TypeError as e:
+            print(e)
+            exit(1)
+        
+
+
+        print(1)
+
+
+
+
 def main():
-    pass
+    home_page = 'https://www.yokohama.com.cn/Check.html'
+
+    browser = Browser(home_page, DEFAULT_UA)
+    browser.run()
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/yokohoma.py
+++ b/scripts/yokohoma.py
@@ -13,47 +13,7 @@ OUTPUT_PATH = os.path.join(PROJECT_ROOT, "output/yokohoma.csv")
 
 
 def main():
-    api = 'https://www.yokohama.com.cn/api/get_comp'
-
-    # 构造请求头和请求体
-
-    payload = ("{\r\n    \"view\": \"Check\",\r\n    \"compId\": \"c_outlets_list_003-1693299992595\","
-               "\r\n    \"params\": \"{\\\"size\\\":2000,\\\"query\\\":[{\\\"valueName\\\":\\\"\\\","
-               "\\\"dataType\\\":\\\"number\\\",\\\"operator\\\":\\\"eq\\\","
-               "\\\"filter\\\":\\\"ignore-empty-check\\\",\\\"esField\\\":\\\"CID\\\",\\\"groupName\\\":\\\"数据展示条件,"
-               "默认条件组\\\",\\\"groupEnd\\\":\\\"2,1\\\",\\\"field\\\":\\\"CID\\\",\\\"sourceType\\\":\\\"page\\\","
-               "\\\"logic\\\":\\\"and\\\",\\\"groupBegin\\\":\\\"1,2\\\",\\\"fieldType\\\":\\\"number\\\"}],"
-               "\\\"header\\\":{\\\"Data-Query-Es-Field\\\":\\\"DETAIL_ES.es_symbol_text_l4B1um48,"
-               "DETAIL_ES.es_symbol_address_420l30H3allAddress,DETAIL_ES.es_symbol_text_7eE767rS,"
-               "DETAIL_ES.es_multi_address_420l30H3tencentMap,DETAIL_ES.es_multi_image_T328TCK7,"
-               "DETAIL_ES.es_float_zdlcm\\\",\\\"Data-Query-Random\\\":0,\\\"Data-Query-Field\\\":\\\"text_l4B1um48,"
-               "address_420l30H3allAddress,text_7eE767rS,address_420l30H3tencentMap,image_T328TCK7,zdlcm\\\"},"
-               "\\\"from\\\":0,\\\"sort\\\":[]}\"\r\n}")
-    headers = {
-        'sec-ch-ua-platform': '"Windows"',
-        'sec-ch-ua': '"Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"',
-        'sec-ch-ua-mobile': '?0',
-        'instance': 'NGC202308040001',
-        'X-Requested-With': 'XMLHttpRequest',
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36',
-        'Accept': 'text/html, */*; q=0.01',
-        'DNT': '1',
-        'Content-Type': 'application/json;charset=UTF-8',
-        'Sec-Fetch-Site': 'same-origin',
-        'Sec-Fetch-Mode': 'cors',
-        'Sec-Fetch-Dest': 'empty',
-        'host': 'www.yokohama.com.cn'
-    }
-
-    try:
-        response = requests.post(api, headers=headers, data=payload)
-        response.raise_for_status()
-        soup_response = BeautifulSoup(response.text, 'html.parser')
-        soup_dealers = soup_response.select('div.e_container-32.s_layout > div')
-        print(1)
-    except requests.exceptions.RequestException as e:
-        print(e)
-        exit(1)
+    pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
优科豪马轮胎，网页上[关于页面](https://www.yokohama.com.cn/Profile.html)声称有超过2500家门店，近年来原开发者爬取的门店数量在1500-1800家不等，然而本脚本只爬到500多家，麻烦大家共同审核代码，若官网确实只能爬取到这些门店，那只能按照现有的代码执行。

另，本脚本引入Page Object设计模式，将一个页面抽象为一个类，其中常用元素的选择器定义为类的常量，常见操作定义为类的方法，这对需要多页面操作的selenium脚本非常有用，例如京东养车（需**登录**）。所有页面都具备的常见操作定义为基类（BasePage），定义在./po/po.py中，可以通过import引用。